### PR TITLE
Recommend six 1.9.0, and have Travis-CI test using that version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ script: coverage run --branch --source=libmodernize setup.py test
 install:
   - pip install .
   - pip install 'coveralls==0.4.2'
-  - pip install 'six >= 1.8.0'
+  - pip install 'six >= 1.9.0'
 after_success:
   coveralls

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ single file::
 It does not guarantee, but it attempts to spit out a codebase compatible
 with Python 2.6+ or Python 3. The code that it generates has a runtime
 dependency on `six <https://pypi.python.org/pypi/six>`_, unless the
-``--no-six`` option is used. Version 1.8.0 or later of ``six`` is
+``--no-six`` option is used. Version 1.9.0 or later of ``six`` is
 recommended. Some of the fixers output code that is not compatible with
 Python 2.5 or lower.
 


### PR DESCRIPTION
Signed-off-by: Daira Hopwood <daira@jacaranda.org>