### PR TITLE
Fix classic division

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+Unreleased
+==========
+
+Changes since 0.4:
+
+* Added the opt-in classic_division fixer.
+
 Version 0.4
 ===========
 

--- a/docs/fixers.rst
+++ b/docs/fixers.rst
@@ -168,7 +168,7 @@ version of ``six`` is installed.
        import six
        class Foo(six.with_metaclass(Meta)):
            pass
-    
+
    .. seealso::
       :func:`six.with_metaclass`
 
@@ -280,6 +280,16 @@ To specify an opt-in fixer while also running all the default fixers, make sure
 to specify the ``-f default`` or ``--fix=default`` option, e.g.::
 
     python-modernize -f default -f libmodernize.fixes.fix_open
+
+.. 2to3fixer:: classic_division
+
+   When a use of the division operator -- ``/`` -- is found, add
+   ``from __future__ import division`` and change the operator to ``//``.
+   This fixer is opt-in because some objects may override the ``__div__`` method
+   for a use other than division and thus would break when suddenly changed to
+   use a ``__floordiv__`` method instead.
+
+   .. versionadded:: 0.5
 
 .. 2to3fixer:: open
 

--- a/libmodernize/fixes/__init__.py
+++ b/libmodernize/fixes/__init__.py
@@ -45,5 +45,6 @@ six_fix_names = set([
 
 # Fixes that are opt-in only.
 opt_in_fix_names = set([
+    'libmodernize.fixes.fix_classic_division',
     'libmodernize.fixes.fix_open',
 ])

--- a/libmodernize/fixes/fix_classic_division.py
+++ b/libmodernize/fixes/fix_classic_division.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+
+from lib2to3 import fixer_base
+from lib2to3 import pytree
+from lib2to3.pgen2 import token
+
+import libmodernize
+
+
+class FixClassicDivision(fixer_base.BaseFix):
+    _accept_type = token.SLASH
+
+    def start_tree(self, tree, name):
+        super(FixClassicDivision, self).start_tree(tree, name)
+        self.skip = "division" in tree.future_features
+
+    def match(self, node):
+        return node.value == "/"
+
+    def transform(self, node, results):
+        if self.skip:
+            return
+        libmodernize.add_future(node, u'division')
+        return pytree.Leaf(token.SLASH, "//", prefix=node.prefix)

--- a/tests/test_fix_classic_division.py
+++ b/tests/test_fix_classic_division.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+
+from utils import check_on_input
+
+
+CLASSIC_DIVISION = ("""\
+1 / 2
+""",
+"""\
+from __future__ import division
+1 // 2
+""")
+
+NEW_DIVISION = ("""\
+from __future__ import division
+1 / 2
+""",
+"""\
+from __future__ import division
+1 / 2
+""")
+
+
+def test_optional():
+    check_on_input(CLASSIC_DIVISION[0], CLASSIC_DIVISION[0])
+
+def test_fix_classic_division():
+    check_on_input(*CLASSIC_DIVISION,
+            extra_flags=['-f', 'libmodernize.fixes.fix_classic_division'])
+
+def test_new_division():
+    check_on_input(*NEW_DIVISION,
+            extra_flags=['-f', 'libmodernize.fixes.fix_classic_division'])


### PR DESCRIPTION
Opt-in due to potential issues with objects that don't support __truediv__/__floordiv__.

Closes #17 