### PR TITLE
Handle parenthesised future imports

### DIFF
--- a/libmodernize/__init__.py
+++ b/libmodernize/__init__.py
@@ -19,8 +19,15 @@ def check_future_import(node):
             node.children[1].type == token.NAME and
             node.children[1].value == u'__future__'):
         return set()
-    node = node.children[3]
+
+    if node.children[3].type == token.LPAR:
+        # from __future__ import (..
+        node = node.children[4]
+    else:
+        # from __future__ import ...
+        node = node.children[3]
     # now node is the import_as_name[s]
+
     # print(python_grammar.number2symbol[node.type])
     if node.type == syms.import_as_names:
         result = set()

--- a/tests/test_future_behaviour.py
+++ b/tests/test_future_behaviour.py
@@ -111,8 +111,20 @@ from __future__ import print_function as pf, division as dv
 print("abc")
 """)
 
+FUTURE_IMPORT_PAREN = ("""\
+from __future__ import (print_function, division)
+print("abc")
+""", """\
+from __future__ import (print_function, division)
+print("abc")
+"""
+)
+
 def test_future_import_as():
     check_on_input(*FUTURE_IMPORT_AS)
 
 def test_future_import_as_multiple():
     check_on_input(*FUTURE_IMPORT_AS_MULTIPLE)
+
+def test_future_import_paren():
+    check_on_input(*FUTURE_IMPORT_PAREN)

--- a/tests/test_future_behaviour.py
+++ b/tests/test_future_behaviour.py
@@ -129,3 +129,4 @@ def test_future_import_as_multiple():
 
 def test_future_import_paren():
     check_on_input(*FUTURE_IMPORT_PAREN)
+

--- a/tests/test_future_behaviour.py
+++ b/tests/test_future_behaviour.py
@@ -112,11 +112,12 @@ print("abc")
 """)
 
 FUTURE_IMPORT_PAREN = ("""\
-from __future__ import (print_function, division)
-print("abc")
+from __future__ import (absolute_import, division, print_function)
+unicode("abc")
 """, """\
-from __future__ import (print_function, division)
-print("abc")
+from __future__ import (absolute_import, division, print_function)
+import six
+six.text_type("abc")
 """
 )
 


### PR DESCRIPTION
Modernising code that did `from __future__ import (...)` was failing.

I couldn't get the test for this to fail - I'm not sure why. But this change made it work on the actual code I was testing with.