### PR TITLE
Enable container-based tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ install:
   - pip install 'six >= 1.9.0'
 after_success:
   coveralls
+sudo: false


### PR DESCRIPTION
If it works, this should make test runs faster, both in terms of actual run time and queueing time for the builds.

http://docs.travis-ci.com/user/workers/container-based-infrastructure/