### PR TITLE
Fix transformation of non-iter dict methods in for loops

### DIFF
--- a/libmodernize/fixes/fix_dict_six.py
+++ b/libmodernize/fixes/fix_dict_six.py
@@ -24,3 +24,9 @@ class FixDictSix(fix_dict.FixDict):
             return super(FixDictSix, self).transform(node, results)
         else:
             return self.transform_iter(method_name, node, results['head'])
+
+    def in_special_context(self, node, isiter):
+        # Redefined from parent class to make "for x in d.items()" count as
+        # in special context; 2to3 only counts for loops as special context
+        # for the iter* methods.
+        return super(FixDictSix, self).in_special_context(node, True)

--- a/tests/test_fix_dict_six.py
+++ b/tests/test_fix_dict_six.py
@@ -27,6 +27,14 @@ x.{type}()
 list(x.{type}())
 """)
 
+DICT_IN_LOOP = ("""\
+for k in x.items():
+    pass
+""", """\
+for k in x.items():
+    pass
+""")
+
 
 def check_all_types(input, output):
     for type_ in TYPES:
@@ -40,3 +48,6 @@ def test_dict_view():
 
 def test_dict_plain():
     check_all_types(*DICT_PLAIN)
+
+def test_dict_in_loop():
+    check_on_input(*DICT_IN_LOOP)


### PR DESCRIPTION
Addresses issue #119 - it's not exactly what the author asked for, but I think it's better ;-)

For some reason, 2to3 only treats a for loop as a special context for iter* methods, so it will add a list() call to e.g. `for x in d.values()`.