### PR TITLE
Add a fixer for instances of `unichr`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Unreleased
 
 * Added the opt-in classic_division fixer.
 * Updated the ``dict_six`` fixer to support ``six.viewitems()`` and friends.
+* New fixer for ``unichr``, changed to ``six.unichr``.
 * Documentation corrections.
 
 

--- a/docs/fixers.rst
+++ b/docs/fixers.rst
@@ -193,6 +193,11 @@ version of ``six`` is installed.
        from six.moves.urllib.parse import quote_plus
        quote_plus('hello world')
 
+.. 2to3fixer:: unichr_type
+
+   Changes all reference of :func:`unichr <python2:unichr>` to
+   :data:`six.unichr`.
+
 .. 2to3fixer:: xrange_six
 
    Changes::

--- a/docs/fixers.rst
+++ b/docs/fixers.rst
@@ -193,7 +193,7 @@ version of ``six`` is installed.
        from six.moves.urllib.parse import quote_plus
        quote_plus('hello world')
 
-.. 2to3fixer:: unichr_type
+.. 2to3fixer:: unichr
 
    Changes all reference of :func:`unichr <python2:unichr>` to
    :data:`six.unichr`.

--- a/libmodernize/fixes/__init__.py
+++ b/libmodernize/fixes/__init__.py
@@ -40,7 +40,7 @@ six_fix_names = set([
     'libmodernize.fixes.fix_unicode',
     'libmodernize.fixes.fix_unicode_type',
     'libmodernize.fixes.fix_urllib_six',
-    'libmodernize.fixes.fix_unichr_type',
+    'libmodernize.fixes.fix_unichr',
     'libmodernize.fixes.fix_xrange_six',
     'libmodernize.fixes.fix_zip',
 ])

--- a/libmodernize/fixes/__init__.py
+++ b/libmodernize/fixes/__init__.py
@@ -40,6 +40,7 @@ six_fix_names = set([
     'libmodernize.fixes.fix_unicode',
     'libmodernize.fixes.fix_unicode_type',
     'libmodernize.fixes.fix_urllib_six',
+    'libmodernize.fixes.fix_unichr_type',
     'libmodernize.fixes.fix_xrange_six',
     'libmodernize.fixes.fix_zip',
 ])

--- a/libmodernize/fixes/fix_unichr.py
+++ b/libmodernize/fixes/fix_unichr.py
@@ -6,7 +6,7 @@ from lib2to3.fixer_util import is_probably_builtin
 import libmodernize
 
 
-class FixUnichrType(fixer_base.ConditionalFix):
+class FixUnichr(fixer_base.ConditionalFix):
     BM_compatible = True
 
     skip_on = 'six.moves.unichr'

--- a/libmodernize/fixes/fix_unichr_type.py
+++ b/libmodernize/fixes/fix_unichr_type.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import
+
+from lib2to3 import fixer_base
+from lib2to3.fixer_util import is_probably_builtin
+
+import libmodernize
+
+
+class FixUnichrType(fixer_base.ConditionalFix):
+    BM_compatible = True
+
+    skip_on = 'six.moves.unichr'
+    PATTERN = """'unichr'"""
+
+    def transform(self, node, results):
+        if self.should_skip(node):
+            return
+        if is_probably_builtin(node):
+            libmodernize.touch_import(u'six', u'unichr', node)

--- a/tests/test_fix_unichr_type.py
+++ b/tests/test_fix_unichr_type.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import
+
+from utils import check_on_input
+
+
+UNICHR_TYPE_REF = ("""\
+isinstance(u'a', unichr)
+""", """\
+from __future__ import absolute_import
+from six import unichr
+isinstance(u'a', unichr)
+""")
+
+UNICHR_TYPE_CALL = ("""\
+unichr(42)
+""", """\
+from __future__ import absolute_import
+from six import unichr
+unichr(42)
+""")
+
+UNICHR_USER_CALL = ("""\
+foobar.unichr(42)
+""", """\
+foobar.unichr(42)
+""")
+
+def test_unichr_type_ref():
+    check_on_input(*UNICHR_TYPE_REF)
+
+
+def test_unichr_type_call():
+    check_on_input(*UNICHR_TYPE_CALL)
+
+
+def test_unichr_user_call():
+    check_on_input(*UNICHR_USER_CALL)

--- a/tests/test_fix_unichr_type.py
+++ b/tests/test_fix_unichr_type.py
@@ -3,15 +3,15 @@ from __future__ import absolute_import
 from utils import check_on_input
 
 
-UNICHR_TYPE_REF = ("""\
-isinstance(u'a', unichr)
+UNICHR_METHOD_REF = ("""\
+converter = unichr
 """, """\
 from __future__ import absolute_import
 from six import unichr
-isinstance(u'a', unichr)
+converter = unichr
 """)
 
-UNICHR_TYPE_CALL = ("""\
+UNICHR_METHOD_CALL = ("""\
 unichr(42)
 """, """\
 from __future__ import absolute_import
@@ -25,12 +25,13 @@ foobar.unichr(42)
 foobar.unichr(42)
 """)
 
-def test_unichr_type_ref():
-    check_on_input(*UNICHR_TYPE_REF)
+
+def test_unichr_method_ref():
+    check_on_input(*UNICHR_METHOD_REF)
 
 
-def test_unichr_type_call():
-    check_on_input(*UNICHR_TYPE_CALL)
+def test_unichr_method_call():
+    check_on_input(*UNICHR_METHOD_CALL)
 
 
 def test_unichr_user_call():


### PR DESCRIPTION
This can be trivially fixed by using the six unichr shim.
