### PR TITLE
Add a flag to python-moderinze to return a non-zero exit code if any fixers needed to be applied.

### DIFF
--- a/libmodernize/main.py
+++ b/libmodernize/main.py
@@ -63,6 +63,9 @@ def main(args=None):
                       "(only useful for Python 2.6+).")
     parser.add_option("--no-six", action="store_true", default=False,
                       help="Exclude fixes that depend on the six package.")
+    parser.add_option("--enforce", action="store_true", default=False,
+                      help="Returns non-zero exit code of any fixers had to be applied.  "
+                           "Useful for enforcing Python 3 compatibility.")
 
     fixer_pkg = 'libmodernize.fixes'
     avail_fixes = set(refactor.get_fixers_from_package(fixer_pkg))
@@ -144,4 +147,9 @@ def main(args=None):
         rt.summarize()
 
     # Return error status (0 if rt.errors is zero)
-    return int(bool(rt.errors))
+    result = bool(rt.errors)
+    # If we are enforcing python 3 compatibility, return a non-zero exit code if we had to modify
+    # any files.
+    if options.enforce:
+        result = result or bool(rt.files)
+    return int(result)

--- a/libmodernize/main.py
+++ b/libmodernize/main.py
@@ -147,9 +147,9 @@ def main(args=None):
         rt.summarize()
 
     # Return error status (0 if rt.errors is zero)
-    result = bool(rt.errors)
+    return_code = int(bool(rt.errors))
     # If we are enforcing python 3 compatibility, return a non-zero exit code if we had to modify
     # any files.
-    if options.enforce:
-        result = result or bool(rt.files)
-    return int(result)
+    if options.enforce and rt.files:
+        return_code |= 2
+    return return_code

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -37,7 +37,9 @@ class B(six.with_metaclass(Meta, object)):
 
 
 def test_no_six():
-    check_on_input(NO_SIX_SAMPLE, NO_SIX_SAMPLE, extra_flags=['--no-six'])
+    check_on_input(NO_SIX_SAMPLE, NO_SIX_SAMPLE,
+                   extra_flags=['--no-six'],
+                   expected_return_code=0)
 
 
 def test_enforce():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -25,5 +25,22 @@ class B(object):
     __metaclass__ = Meta
 """
 
+EXPECTED_SIX_RESULT = """\
+from __future__ import absolute_import
+import six
+from six.moves import range
+a = list(range(10))
+
+class B(six.with_metaclass(Meta, object)):
+    pass
+"""
+
+
 def test_no_six():
     check_on_input(NO_SIX_SAMPLE, NO_SIX_SAMPLE, extra_flags=['--no-six'])
+
+
+def test_enforce():
+    check_on_input(NO_SIX_SAMPLE, EXPECTED_SIX_RESULT,
+                   extra_flags=['--enforce'],
+                   expected_return_code=2)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,8 @@ import shutil
 from libmodernize.main import main as modernize_main
 
 
-def check_on_input(input_content, expected_content, extra_flags = []):
+def check_on_input(input_content, expected_content, extra_flags = [],
+                   expected_return_code = None):
     """
     Check that input_content is fixed to expected_content, idempotently.
 
@@ -22,8 +23,13 @@ def check_on_input(input_content, expected_content, extra_flags = []):
         with open(test_input_name, "wt") as input_file:
             input_file.write(input_content)
 
-        def _check(this_input_content, which_check):
-            modernize_main(extra_flags + ["-w", test_input_name])
+        def _check(this_input_content, which_check, check_return_code=True):
+            return_code = modernize_main(extra_flags + ["-w", test_input_name])
+
+            if check_return_code and expected_return_code is not None:
+                if expected_return_code != return_code:
+                    raise AssertionError("Actual return code: %s\nExpected return code: %s" %
+                                         (return_code, expected_return_code))
 
             output_content = ""
             with open(test_input_name, "rt") as output_file:
@@ -37,6 +43,6 @@ def check_on_input(input_content, expected_content, extra_flags = []):
 
         _check(input_content, "output check failed")
         if input_content != expected_content:
-            _check(expected_content, "idempotence check failed")
+            _check(expected_content, "idempotence check failed", check_return_code=False)
     finally:
         shutil.rmtree(tmpdirname)


### PR DESCRIPTION
This is very useful for us when using python-moderize in CI to ensure
we don't regress Python 3 compat.  Otherwise, we have to roll our own
way using git.  For example:

https://github.com/zulip/zulip/blob/master/tools/check-py3#L103