### PR TITLE
Enable `fix_renames` by default

### DIFF
--- a/libmodernize/fixes/__init__.py
+++ b/libmodernize/fixes/__init__.py
@@ -15,6 +15,7 @@ lib2to3_fix_names = set([
     'lib2to3.fixes.fix_operator',
     'lib2to3.fixes.fix_paren',
     'lib2to3.fixes.fix_reduce',
+    'lib2to3.fixes.fix_renames',
     'lib2to3.fixes.fix_repr',
     'lib2to3.fixes.fix_set_literal',
     'lib2to3.fixes.fix_standarderror',


### PR DESCRIPTION
`fix_renames` only replaces `sys.maxint` with `sys.maxsize`, which is also present in Python 2.

https://hg.python.org/cpython/file/2.7/Lib/lib2to3/fixes/fix_renames.py