### PR TITLE
Monkey patch iterating context to include dict.

### DIFF
--- a/libmodernize/__init__.py
+++ b/libmodernize/__init__.py
@@ -7,6 +7,21 @@ from lib2to3.pgen2 import token
 
 __version__ = '0.5'
 
+_fixed_p1 = """
+power<
+    ( 'iter' | 'list' | 'tuple' | 'sorted' | 'set' | 'sum' | 'dict' |
+      'any' | 'all' | 'enumerate' | (any* trailer< '.' 'join' >) )
+    trailer< '(' node=any ')' >
+    any*
+>
+"""
+
+
+def monkey_patch_fixer_util():
+    fixer_util.p1 = _fixed_p1
+    fixer_util.pats_built = False
+
+
 def check_future_import(node):
     """If this is a future import, return set of symbols that are imported,
     else return None."""

--- a/libmodernize/main.py
+++ b/libmodernize/main.py
@@ -13,8 +13,8 @@ import optparse
 
 from lib2to3.main import warn, StdoutRefactoringTool
 from lib2to3 import refactor
-
-from libmodernize import __version__
+from libmodernize import __version__, monkey_patch_fixer_util
+monkey_patch_fixer_util()
 from libmodernize.fixes import lib2to3_fix_names, six_fix_names, opt_in_fix_names
 
 usage = __doc__ + """\

--- a/tests/test_fix_zip.py
+++ b/tests/test_fix_zip.py
@@ -19,6 +19,14 @@ from six.moves import zip
 list(zip(x))
 """)
 
+ZIP_DICT_CONTEXT = ("""\
+dict(zip(x))
+""", """\
+from __future__ import absolute_import
+from six.moves import zip
+dict(zip(x))
+""")
+
 ZIP_CALL_2_ARGS = ("""\
 zip(x, y)
 zip(w, z)
@@ -61,4 +69,7 @@ def test_zip_call_star_args():
     check_on_input(*ZIP_CALL_STAR_ARGS)
 
 def test_zip_iterator_context():
+    check_on_input(*ZIP_ITERATOR_CONTEXT)
+
+def test_zip_dict_context():
     check_on_input(*ZIP_ITERATOR_CONTEXT)


### PR DESCRIPTION
There is a bug in 2to3 which causes calls like `zip` to be wrapped in a `list` when
being passed into a dict constructor.  This is not needed.

```python
dict(zip(foo))
dict(list(zip(foo)))
```