### PR TITLE
Automatically fix `urlparse` imports

### DIFF
--- a/libmodernize/fixes/fix_imports_six.py
+++ b/libmodernize/fixes/fix_imports_six.py
@@ -56,6 +56,7 @@ class FixImportsSix(fix_imports.FixImports):
         'tkSimpleDialog': 'six.moves.tkinter_tksimpledialog',
         'ttk': 'six.moves.tkinter_ttk',
         # urllib
+        'urlparse' : 'six.moves.urllib.parse',
         # UserDict.UserDict
         # UserList.UserList
         # UserString.UserString


### PR DESCRIPTION
Everything under `urlparse` moved to `six.moves.urllib.parse`