### PR TITLE
Travis CI: Drop Python 3.3 and add Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 # command to run tests
 script: coverage run --branch --source=libmodernize setup.py test
 # Ensure dependencies are installed


### PR DESCRIPTION
Python 3.3 goes EOL this month https://docs.python.org/devguide/index.html#branchstatus