### PR TITLE
Don't add 'absolute_import' futures indiscriminately

### DIFF
--- a/libmodernize/__init__.py
+++ b/libmodernize/__init__.py
@@ -77,7 +77,6 @@ def add_future(node, symbol):
 
 
 def touch_import(package, name, node):
-    add_future(node, 'absolute_import')
     fixer_util.touch_import(package, name, node)
 
 

--- a/tests/test_fix_open.py
+++ b/tests/test_fix_open.py
@@ -6,7 +6,6 @@ from utils import check_on_input
 OPEN = ("""\
 {0}('some/path')
 """, """\
-from __future__ import absolute_import
 from io import open
 open('some/path')
 """)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,12 +10,14 @@ from libmodernize.main import main as modernize_main
 def check_on_input(input_content, expected_content, extra_flags = [],
                    expected_return_code = None):
     """
-    Check that input_content is fixed to expected_content, idempotently.
-
-    Writes input_content to a temporary file, runs modernize on it with any
-    extra arguments as given in extra_flags, and asserts that the resulting file
-    matches expected_content. Then, runs modernize again with any extra arguments,
-    and asserts that the second run makes no changes.
+    Check that input_content is fixed to expected_content, idempotently:
+        Writes input_content to a temporary file
+        Runs modernize on it with any extra arguments as given in extra_flags
+        Runs modernize again with the same arguments, to flush out cumulative effects
+            (e.g., 'import' fixer isn't triggered until an import exists)
+        Asserts that the resulting file matches expected_content
+        Runs modernize again with any extra arguments
+        Asserts that the final run makes no changes
     """
     tmpdirname = tempfile.mkdtemp()
     try:
@@ -24,6 +26,14 @@ def check_on_input(input_content, expected_content, extra_flags = [],
             input_file.write(input_content)
 
         def _check(this_input_content, which_check, check_return_code=True):
+            return_code = modernize_main(extra_flags + ["-w", test_input_name])
+
+            if check_return_code and expected_return_code is not None:
+                if expected_return_code != return_code:
+                    raise AssertionError("Actual return code: %s\nExpected return code: %s" %
+                                         (return_code, expected_return_code))
+
+            # Second pass to deal with cumulative effects that affect 'import'
             return_code = modernize_main(extra_flags + ["-w", test_input_name])
 
             if check_return_code and expected_return_code is not None:


### PR DESCRIPTION
Currently the 'absolute_import' future is added anywhere a non-future import happens. This branch removes that side-effect. The existing 'import' fixer has a very similar effect and can be directly enabled or disabled by the user.

Fixes #163 #142 