### PR TITLE
Support user-provided fixers (fixes #166)

### DIFF
--- a/docs/fixers.rst
+++ b/docs/fixers.rst
@@ -21,6 +21,15 @@ then use the ``--no-six`` flag.
 Fixers use the API defined by 2to3. For details of how this works, and how to
 implement your own fixers, see `Extending 2to3 with your own fixers, at
 python3porting.com <http://python3porting.com/fixers.html>`_.
+``python-modernize`` will try to load fixers whose full dotted-path is specified
+as a ``-f`` argument, but will fail if they are not found. By default, fixers
+will not be found in the current directory; use ``--fixers-here`` to make
+``python-modernize`` look for them there, or see the `Python tutorial on
+modules <https://docs.python.org/3/tutorial/modules.html>`_ (in particular,
+the parts on the `search path
+<https://docs.python.org/3/tutorial/modules.html#the-module-search-path>`_
+and `packages <https://docs.python.org/3/tutorial/modules.html#packages>`_)
+for more info on how Python finds modules.
 
 
 Default

--- a/libmodernize/main.py
+++ b/libmodernize/main.py
@@ -113,7 +113,8 @@ def main(args=None):
             if tgt == fix or tgt.endswith(".fix_{}".format(fix)):
                 matched = tgt
                 unwanted_fixes.add(matched)
-        if matched is None:
+                break
+        else:
             print("Error: fix '{}' was not found".format(fix),
                   file=sys.stderr)
             return 2
@@ -147,7 +148,8 @@ def main(args=None):
                     if tgt == fix or tgt.endswith(".fix_{}".format(fix)):
                         matched = tgt
                         explicit.add(matched)
-                if matched is None:
+                        break
+                else:
                     print("Error: fix '{}' was not found".format(fix),
                           file=sys.stderr)
                     return 2

--- a/libmodernize/main.py
+++ b/libmodernize/main.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, print_function
 import sys
 import logging
 import optparse
+import os
 
 from lib2to3.main import warn, StdoutRefactoringTool
 from lib2to3 import refactor
@@ -23,9 +24,11 @@ usage = __doc__ + """\
 Usage: modernize [options] file|dir ...
 """ % __version__
 
+
 def format_usage(usage):
     """Method that doesn't output "Usage:" prefix"""
     return usage
+
 
 def main(args=None):
     """Main program.
@@ -41,11 +44,13 @@ def main(args=None):
     parser.add_option("--no-diffs", action="store_true",
                       help="Don't show diffs of the refactoring.")
     parser.add_option("-l", "--list-fixes", action="store_true",
-                      help="List available transformations.")
+                      help="List standard transformations.")
     parser.add_option("-d", "--doctests_only", action="store_true",
                       help="Fix up doctests only.")
     parser.add_option("-f", "--fix", action="append", default=[],
                       help="Each FIX specifies a transformation; '-f default' includes default fixers.")
+    parser.add_option("--fixers-here", action="store_true",
+                      help="Add current working directory to python path (so fixers can be found)")
     parser.add_option("-j", "--processes", action="store", default=1,
                       type="int", help="Run 2to3 concurrently.")
     parser.add_option("-x", "--nofix", action="append", default=[],
@@ -80,7 +85,7 @@ def main(args=None):
     if not options.write and options.nobackups:
         parser.error("Can't use '-n' without '-w'.")
     if options.list_fixes:
-        print("Available transformations for the -f/--fix and -x/--nofix options:")
+        print("Standard transformations available for the -f/--fix and -x/--nofix options:")
         for fixname in sorted(avail_fixes):
             print("    {}  ({})".format(fixname, fixname.split(".fix_", 1)[1]))
         print()
@@ -97,6 +102,8 @@ def main(args=None):
             return 2
     if options.print_function:
         flags["print_function"] = True
+    if options.fixers_here:
+        sys.path.append(os.getcwd())
 
     # Set up logging handler
     level = logging.DEBUG if options.verbose else logging.INFO
@@ -150,9 +157,8 @@ def main(args=None):
                         explicit.add(matched)
                         break
                 else:
-                    print("Error: fix '{}' was not found".format(fix),
-                          file=sys.stderr)
-                    return 2
+                    # A non-standard fix -- trust user to have supplied path
+                    explicit.add(fix)
         requested = default_fixes.union(explicit) if default_present else explicit
     else:
         requested = default_fixes


### PR DESCRIPTION
This adds support for user-provided fixers in the `python-modernize` command -- or, rather, mostly, removes the blocking of their use.

I found that, when the command-line tool is invoked, the current working directory is not on the Python-path -- which means user-provided fixers are likely not to be found. I added a command-line flag to help remedy this, thinking that by default, we don't want random modules to mix into the library.

I made what I think are the relevant documentation changes, criticism very welcome there. English is not my native language.

I looked for tests, and found essentially none for similar functionality of the main module, so I skipped those; if you think it necessary, I'll add them.

I also included a separate commit which prevents a single `-f` option from referring to more than one fixer; this possibility was introduced with the support for short names. It is not a condition for user-provided fixers, each can be accepted or rejected separately.

This work was sponsored by Matific at https://matific.com