### PR TITLE
Make python -m modernize return correct exit code

### DIFF
--- a/modernize.py
+++ b/modernize.py
@@ -1,4 +1,7 @@
 from __future__ import absolute_import
 
+import sys
+
 from libmodernize.main import main
-main()
+
+sys.exit(main())


### PR DESCRIPTION
## What

- This PR updates `modernize.py` so that `python -m modernize` returns the same exit code as invoking `libmodernize.main` directly.

## Why

Should close https://github.com/python-modernize/python-modernize/issues/171:

> I'm seeing some inconsistencies with exit codes depending on how `python-modernize` is invoked on the command line...e.g. invoking the binary directly like `python-modernize` yields a different error code than `python -m modernize`:
> ```
> $ python-modernize this-file-does-not-exist.py
> etc.
> RefactoringTool: No files need to be modified.
> RefactoringTool: There was 1 error:
> RefactoringTool: Can't open this-file-does-not-exist.py: [Errno 2] No such file or directory: 'this-file-does-not-exist.py'
> $ echo $?
> 1
> 
> $ python -m modernize this-file-does-not-exist.py
> etc.
> RefactoringTool: No files need to be modified.
> RefactoringTool: There was 1 error:
> RefactoringTool: Can't open this-file-does-not-exist.py: [Errno 2] No such file or directory: 'this-file-does-not-exist.py'
> $ echo $?
> 0
> ```

@takluyver I didn't see an obvious way to cover this change/bug with a test case. Do you have any ideas?