### PR TITLE
Add https://pre-commit.com metadata

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+-   id: python-modernize
+    name: python-modernize
+    description: Modernizes Python code for eventual Python 3 migration.
+    entry: python-modernize
+    args: [--write, --fix=default, --nobackups]
+    language: python
+    types: [python]


### PR DESCRIPTION
This is WIP, I wanted to get some feedback on whether this is desirable and if so where to document this :)

[pre-commit](https://github.com/pre-commit/pre-commit) is a mutli-language git hooks framework and perhaps more importantly a linter-runner framework.

This metadata makes it very easy to add `python-modernize` to a repository that's  already using the pre-commit framework.